### PR TITLE
Do not always install udev file to the system

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,6 +26,6 @@ set(UDEV_RULES_PATH
 install(FILES ${LIB} DESTINATION lib/)
 install(FILES ${HEADERS} DESTINATION include/indemind/)
 install(FILES ${SHARE} DESTINATION share/indemind/cmake/)
-if (UNIX)
+if (UNIX AND INSTALL_UDEV_SYSTEM)
     install(FILES ${RULES} DESTINATION ${UDEV_RULES_PATH})
 endif()

--- a/README.md
+++ b/README.md
@@ -4,6 +4,11 @@
 ```bash
 mkdir build
 cd build
+# Without installing the udev rules on the current system
 cmake .. -DCMAKE_INSTALL_PREFIX=<install_path>
+make install
+# or installing the udev rules on the system (requires root privileges)
+cmake .. -DCMAKE_INSTALL_PREFIX=<install_path> -DINSTALL_UDEV_SYSTEM=true
 sudo make install
 ```
+


### PR DESCRIPTION
Currently the user is forced to have root permissions on the system when
using the `install` target. This can cause problems with tkDeps or Yocto
build or, more in general, with automatic build systems where usually
we don't have root permission and we would have at least the opportunity
to chose if we want to install something on the root system.
Make the udev install optional using a variable. Update the Readme with
the new option.

Signed-off-by: Luca Miccio <lucmiccio@gmail.com>